### PR TITLE
TypeError: Argument 2 passed to Horde_Db_Adapter_Base::_replaceParameters()

### DIFF
--- a/lib/Faces/Base.php
+++ b/lib/Faces/Base.php
@@ -652,7 +652,10 @@ class Ansel_Faces_Base
                 array('face_signature' => new Horde_Db_Value_Binary(
                      puzzle_compress_cvec($signature))
                 ),
-                array('face_id = ?', $face_id)
+                array(
+                    'face_id = ?', 
+                    array($face_id)
+                )
             );
         } catch (Horde_Db_Exception $e) {
             throw new Ansel_Exception($result);


### PR DESCRIPTION
when we do a automatic face detection whit libpuzzle enabled we got an error about wrong argument type

```
2017-10-22T12:17:22+00:00 EMERG: HORDE [ansel] TypeError: Argument 2 passed to Horde_Db_Adapter_Base::_replaceParameters() must be of the type array, integer given, called in /usr/share/php/Horde/Db/Adapter/Pdo/Base.php on line 364 and defined in /usr/share/php/Horde/Db/Adapter/Base.php:784
Stack trace:
#0 /usr/share/php/Horde/Db/Adapter/Pdo/Base.php(364): Horde_Db_Adapter_Base->_replaceParameters('face_id = ?', 5)
#1 /srv/www/docs/ansel/lib/Faces/Base.php(655): Horde_Db_Adapter_Pdo_Base->updateBlob('ansel_faces', Array, Array)
#2 /srv/www/docs/ansel/lib/Faces/Base.php(554): Ansel_Faces_Base->saveSignature(4947, 5)
#3 /srv/www/docs/ansel/lib/Ajax/Imple/EditFaces.php(50): Ansel_Faces_Base->getFromPicture(Object(Ansel_Image), true)
#4 /usr/share/php/Horde/Core/Ajax/Imple.php(120): Ansel_Ajax_Imple_EditFaces->_handle(Object(Horde_Variables))
#5 /usr/share/php/Horde/Core/Ajax/Application/Handler/Imple.php(31): Horde_Core_Ajax_Imple->handle(Object(Horde_Variables))
#6 /usr/share/php/Horde/Core/Ajax/Application.php(175): Horde_Core_Ajax_Application_Handler_Imple->imple()
#7 /srv/www/docs/services/ajax.php(61): Horde_Core_Ajax_Application->doAction()
#8 {main} [pid 13479 on line 74 of "/usr/share/php/Horde/ErrorHandler.php"]
```