### PR TITLE
fix: Support both old-style Horde_Variables and modern Horde\Util\Variables

### DIFF
--- a/lib/Ajax/Imple/EditCaption.php
+++ b/lib/Ajax/Imple/EditCaption.php
@@ -1,5 +1,7 @@
 <?php
 
+use Horde\Util\Variables;
+
 /**
  * Imple for performing AJAX setting of image captions.
  *
@@ -12,7 +14,7 @@ class Ansel_Ajax_Imple_EditCaption extends Horde_Core_Ajax_Imple_InPlaceEditor
 {
     /**
      */
-    protected function _handleEdit(Horde_Variables $vars)
+    protected function _handleEdit(Variables|Horde_Variables $vars)
     {
         $as = $GLOBALS['injector']->getInstance('Ansel_Storage');
         try {

--- a/lib/Ajax/Imple/EditFaces.php
+++ b/lib/Ajax/Imple/EditFaces.php
@@ -1,5 +1,7 @@
 <?php
 
+use Horde\Util\Variables;
+
 /**
  * Imple for performing Ajax discovery and editing of image faces.
  *
@@ -35,7 +37,7 @@ class Ansel_Ajax_Imple_EditFaces extends Horde_Core_Ajax_Imple
 
     /**
      */
-    protected function _handle(Horde_Variables $vars)
+    protected function _handle(Variables|Horde_Variables $vars)
     {
         global $injector, $prefs;
 

--- a/lib/Ajax/Imple/ToggleGalleryActions.php
+++ b/lib/Ajax/Imple/ToggleGalleryActions.php
@@ -1,5 +1,7 @@
 <?php
 
+use Horde\Util\Variables;
+
 /**
  * Ansel_Ajax_Imple_ToggleGalleryActions:: class for performing Ajax setting of
  * the gallery show_galleryactions user pref.
@@ -25,7 +27,7 @@ class Ansel_Ajax_Imple_ToggleGalleryActions extends Horde_Core_Ajax_Imple
     /**
      * Noop.
      */
-    protected function _handle(Horde_Variables $vars)
+    protected function _handle(Variables|Horde_Variables $vars)
     {
     }
 

--- a/lib/Ajax/Imple/ToggleOtherGalleries.php
+++ b/lib/Ajax/Imple/ToggleOtherGalleries.php
@@ -1,5 +1,7 @@
 <?php
 
+use Horde\Util\Variables;
+
 /**
  * Ansel_Ajax_Imple_ToggleOtherGalleries:: class for performing Ajax setting of
  * the gallery show_actions user pref.
@@ -25,7 +27,7 @@ class Ansel_Ajax_Imple_ToggleOtherGalleries extends Horde_Core_Ajax_Imple
     /**
      * Noop.
      */
-    protected function _handle(Horde_Variables $vars)
+    protected function _handle(Variables|Horde_Variables $vars)
     {
     }
 


### PR DESCRIPTION
See also:
horde/base#58
horde/kronolith#21
horde/gollem@1b3af38
horde/wicked#12
horde/whups#5
horde/imp#30
horde/nag@9376885
horde/turba#30
horde/mnemo#12
horde/ingo#16
horde/hermes#2
horde/passwd#8
horde/vilma#1